### PR TITLE
Fixed error when handling non-integer values in merged_lead_id in Snowflake

### DIFF
--- a/models/stg_marketo__lead.sql
+++ b/models/stg_marketo__lead.sql
@@ -20,7 +20,7 @@ with leads as (
         cast(merged_lead_id as INT64) as lead_id,
         cast(lead_id as string) as merged_into_lead_id
         {% else %}
-        cast(merged_lead_id as integer) as lead_id,
+        try_cast(merged_lead_id as integer) as lead_id,
         cast(lead_id as varchar) as merged_into_lead_id
         {% endif %}
     from merged_leads


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Yes. Lynzi, VP Data Strategy & Operations, Renaissance Learning, Inc

**What change(s) does this PR introduce?** 
The 'cast' to integer in this model errored out on the 3 values in our Marketo leads table with non-numeric values in merged_lead_id. Replaced cast with try_cast to avoid this on Snowflake. 

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  -- this works in snowflake

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes, Issue [link issue number here]
- [ x] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other -- I updated it in my local dbt environment and ran dbt test and dbt run successfully

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
