### PR TITLE
cast activity date as timestamp without tz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # dbt_marketo_source v0.7.1
 
 ## Bug Fixes
-- Explicitly cast the activity_timestamp field as `timestamp without time zone`, otherwise in Redshift this would be passed down as `timestamp with time zone` and cause date functions to fail 
+- Explicitly cast the activity_timestamp field as `timestamp without time zone`, otherwise in Redshift this would be passed down as `timestamp with time zone` and cause date functions to fail (https://github.com/fivetran/dbt_marketo_source/issues/22)
+[#23](https://github.com/fivetran/dbt_marketo_source/pull/23)
 # dbt_marketo_source v0.7.0
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt_marketo_source v0.7.1
+
+## Bug Fixes
+- Explicitly cast the activity_timestamp field as `timestamp without time zone`, otherwise in Redshift this would be passed down as `timestamp with time zone` and cause date functions to fail 
 # dbt_marketo_source v0.7.0
 
 ## Bug Fixes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'marketo_source'
-version: '0.7.0'
+version: '0.7.1'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'marketo_source_integration_tests'
-version: '0.7.0'
+version: '0.7.1'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/stg_marketo.yml
+++ b/models/stg_marketo.yml
@@ -10,7 +10,7 @@ models:
           - not_null
             
       - name: activity_timestamp
-        description: Timestamp of the actvity.
+        description: Timestamp of the activity.
             
       - name: activity_type_id
         description: ID of the activity type.
@@ -56,7 +56,7 @@ models:
           - not_null
             
       - name: activity_timestamp
-        description: Timestamp of the actvity.
+        description: Timestamp of the activity.
             
       - name: activity_type_id
         description: ID of the activity type.

--- a/models/stg_marketo__activity_change_data_value.sql
+++ b/models/stg_marketo__activity_change_data_value.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         api_method_name,
         campaign_id,

--- a/models/stg_marketo__activity_change_data_value.sql
+++ b/models/stg_marketo__activity_change_data_value.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         api_method_name,
         campaign_id,

--- a/models/stg_marketo__activity_click_email.sql
+++ b/models/stg_marketo__activity_click_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_click_email.sql
+++ b/models/stg_marketo__activity_click_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_delete_lead.sql
+++ b/models/stg_marketo__activity_delete_lead.sql
@@ -19,7 +19,7 @@ with base as (
     select
         id as activity_id,
         _fivetran_synced,
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign as campaign_name,
         campaign_id,

--- a/models/stg_marketo__activity_delete_lead.sql
+++ b/models/stg_marketo__activity_delete_lead.sql
@@ -19,7 +19,7 @@ with base as (
     select
         id as activity_id,
         _fivetran_synced,
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign as campaign_name,
         campaign_id,

--- a/models/stg_marketo__activity_email_bounced.sql
+++ b/models/stg_marketo__activity_email_bounced.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 	
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_email_bounced.sql
+++ b/models/stg_marketo__activity_email_bounced.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 	
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_email_delivered.sql
+++ b/models/stg_marketo__activity_email_delivered.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_email_delivered.sql
+++ b/models/stg_marketo__activity_email_delivered.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_merge_leads.sql
+++ b/models/stg_marketo__activity_merge_leads.sql
@@ -19,7 +19,7 @@ with base as (
     select
         id as activity_id,
         _fivetran_synced,
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         lead_id,

--- a/models/stg_marketo__activity_merge_leads.sql
+++ b/models/stg_marketo__activity_merge_leads.sql
@@ -19,7 +19,7 @@ with base as (
     select
         id as activity_id,
         _fivetran_synced,
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         lead_id,

--- a/models/stg_marketo__activity_open_email.sql
+++ b/models/stg_marketo__activity_open_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_open_email.sql
+++ b/models/stg_marketo__activity_open_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_send_email.sql
+++ b/models/stg_marketo__activity_send_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_send_email.sql
+++ b/models/stg_marketo__activity_send_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_unsubscribe_email.sql
+++ b/models/stg_marketo__activity_unsubscribe_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 	
-        activity_date as activity_timestamp,
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
         activity_type_id,
         campaign_id,
         campaign_run_id,

--- a/models/stg_marketo__activity_unsubscribe_email.sql
+++ b/models/stg_marketo__activity_unsubscribe_email.sql
@@ -17,7 +17,7 @@ with base as (
 ), fields as (
 
     select 	
-        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp, -- ensure timestamp is passed without timezone in Redshift 
+        cast(activity_date as {{ dbt_utils.type_timestamp() }}) as activity_timestamp,
         activity_type_id,
         campaign_id,
         campaign_run_id,


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Internal
**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
- Explicitly cast the `activity_timestamp` field as `timestamp without time zone`, otherwise in Redshift this would be passed down as `timestamp with time zone` and cause date functions to fail 
**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)
Bug fix for redshift users
**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature [22](https://github.com/fivetran/dbt_marketo_source/issues/22)
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] BigQuery
- [x] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
